### PR TITLE
(#47) Add geoblacklight-messaging plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /yarn-error.log
 
 .byebug_history
+
+.db/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 cache: bundler
 language: ruby
+sudo: required
 services:
   - postgresql
+  - rabbitmq
 before_script:
   - psql -c 'create database geo_lclark_test;' -U postgres
 rvm:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,13 @@ RUN bundle install
 ENV RAILS_ENV "production"
 ENV RAILS_SERVE_STATIC_FILES "true"
 ENV SOLR_URL "http://solr:8983/solr/geoblacklight"
+ENV RABBIT_SERVER "amqp://mq:5672"
 ENV DEVISE_SECRET_KEY "$(rake secret)"
 ENV SECRET_KEY_BASE "$(rake secret)"
 
 # Persist data
 VOLUME ["/usr/src/geoblacklight/tmp"]
 
-# Start the app
+# Compile assets and expose port
 RUN rake assets:precompile
-CMD ["sh", "-c", "/usr/src/geoblacklight/bin/start"]
+EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Use RabbitMQ for synchronizing index
+gem 'geoblacklight_messaging'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    amq-protocol (2.2.0)
     arel (8.0.0)
     autoprefixer-rails (7.1.4.1)
       execjs
@@ -59,6 +60,8 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
+    bunny (2.7.1)
+      amq-protocol (>= 2.2.0)
     byebug (9.1.0)
     capybara (2.15.1)
       addressable
@@ -122,6 +125,9 @@ GEM
       leaflet-rails (~> 0.7.3)
       rails (~> 5.0)
     geoblacklight-icons (1.1.0)
+    geoblacklight_messaging (0.2.1)
+      rails
+      sneakers
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     hashie (3.5.6)
@@ -269,6 +275,14 @@ GEM
     selenium-webdriver (3.6.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    serverengine (1.5.11)
+      sigdump (~> 0.2.2)
+    sigdump (0.2.4)
+    sneakers (2.6.0)
+      bunny (~> 2.7.0)
+      concurrent-ruby (~> 1.0)
+      serverengine (~> 1.5.11)
+      thor
     solr_wrapper (1.1.0)
       faraday
       retriable
@@ -324,6 +338,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.6)
   geoblacklight (>= 1.4)
+  geoblacklight_messaging
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Lewis and Clark's [Geoblacklight](http://geoblacklight.org/) instance hosted at 
 
 2. [Ruby](https://www.ruby-lang.org/en/documentation/installation/) >= 2.2.5
 
+3. [RabbitMQ](https://www.rabbitmq.com/download.html)
+
 ### Installing
 
 1. Clone the repository:

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@
 require_relative 'config/application'
 require 'solr_wrapper/rake_task' unless Rails.env.production?
 
+require 'sneakers/tasks'
 Rails.application.load_tasks
 
 # Clearing out the original rake test task that runs minitest

--- a/bin/start
+++ b/bin/start
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-sleep 15
-rake db:migrate
-bin/rails s -b 0.0.0.0

--- a/config/initializers/messaging_config.rb
+++ b/config/initializers/messaging_config.rb
@@ -1,0 +1,13 @@
+module Messaging
+  def config
+    @config ||= config_yaml.with_indifferent_access
+  end
+
+  private
+
+  def config_yaml
+    YAML.load(ERB.new(File.read("#{Rails.root}/config/messaging.yml")).result)[Rails.env]
+  end
+
+  module_function :config, :config_yaml
+end

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -1,0 +1,8 @@
+require 'sneakers'
+require_relative 'messaging_config'
+Sneakers.configure(
+  amqp: Messaging.config['events']['server'],
+  exchange: Messaging.config['events']['exchange']['geoblacklight'],
+  exchange_type: :fanout
+)
+Sneakers.logger.level = Logger::INFO

--- a/config/messaging.yml
+++ b/config/messaging.yml
@@ -1,0 +1,17 @@
+defaults: &defaults
+  events:
+    server: <%= ENV.fetch('RABBIT_SERVER') { 'amqp://localhost:5672' } %>
+    exchange:
+      geoblacklight: 'gbl_events'
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults
+
+staging:
+  <<: *defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,42 @@
-version: '3.1'
+version: '2'
 
 services:
 
-  db:
-    image: postgres
-
-  geoblacklight:
+  app:
     build: .
-    ports:
-      - 3000:3000
     environment:
       SOLR_URL: http://geo.lclark.edu:8983/solr/geoblacklight
       SUBMIT_URL: http://geo.lclark.edu/submit
+
+  db:
+    image: postgres
+    volumes:
+      - ./.db:/var/lib/postgresql/data
+
+  mq:
+    image: rabbitmq:management
+    ports:
+      - 3001:15672
+
+  web:
+    extends: app
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3000 -b '0.0.0.0'"
+    depends_on:
+      - db
+      - db_migrate
+    ports:
+      - 3000:3000
+
+  workers:
+    extends: app
+    command: bash -c "sleep 20 && WORKERS=GeoblacklightMessaging::GeoblacklightEventHandler rake sneakers:run"
+    depends_on:
+      - db
+      - db_migrate
+      - mq
+
+  db_migrate:
+    extends: app
+    command: rake db:migrate
+    depends_on:
+      - db


### PR DESCRIPTION
closes #47 

- adds `geoblacklight-messaging` gem
- reworks `docker-compose.yml` to use `extends:` for startup tasks (requires v2 syntax)
- edits Dockerfile to remove `start` script, as its tasks run in containers now
- adds rabbitmq and workers containers to stack
- adds rabbitmq to travis builds