### PR TITLE
remove figs

### DIFF
--- a/Figsfile
+++ b/Figsfile
@@ -1,4 +1,0 @@
---- !ruby/object:Figs::Figsfile
-locations:
-- application.yml
-method: path

--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,6 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use figs to store credentials
-gem "figs"
-
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,8 +105,6 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.18)
-    figs (2.0.0)
-      git (~> 1.2.6)
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
     geo_combine (0.3.1)
@@ -131,7 +129,6 @@ GEM
     geoblacklight_messaging (0.2.1)
       rails
       sneakers
-    git (1.2.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.9.0)
@@ -321,7 +318,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   devise_saml_authenticatable
-  figs
   geo_combine
   geoblacklight (>= 1.4)
   geoblacklight_messaging
@@ -344,4 +340,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,9 +6,6 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require 'figs'
-Figs.load()
-
 module Compass
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,6 @@ test:
 
 production:
   <<: *default
-  host: <%= ENV.fetch("PROD_DB_HOST") { "db" } %>
-  port: <%= ENV.fetch("PROD_DB_PORT") { 5432 } %>
-  user: <%= ENV.fetch("PROB_DB_USER") { "postgres" } %>
+  host: <%= ENV.fetch("DB_HOST") { "db" } %>
+  port: <%= ENV.fetch("DB_PORT") { 5432 } %>
+  user: <%= ENV.fetch("DB_USER") { "postgres" } %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,21 +12,7 @@
 
 # Shared secrets are available across all environments.
 
-# shared:
-#   api_key: a1B2c3D4e5F6
+shared:
+  secret_key_base: cb63c3de3016ffe0bb965398137d0ddde71fbe9ce9cd4d1db26ae96a0ed9fcb05fe354c050241e4b23821beae6a77903ee38033e305f6ecfc8043096222defb9
 
 # Environmental secrets are only available for that specific environment.
-
-development:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-
-test:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-
-# Do not keep production secrets in the unencrypted secrets file.
-# Instead, either read values from the environment.
-# Or, use `bin/rails secrets:setup` to configure encrypted secrets
-# and move the `production:` environment over there.
-
-production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
exposes `secret_key` since it probably doesn't matter and apparently `rake precompile` needs it. everything else can be handled thru ENV.